### PR TITLE
Added method for getting contents by list of IDs

### DIFF
--- a/setup-mongo.js
+++ b/setup-mongo.js
@@ -21,7 +21,7 @@ var unpublishedContent = {
   "published" : false
 };
 
-var publishedContent = { 
+var publishedContent2 = { 
     "_id" : new ObjectID.createFromHexString("56b891d78a456d13026afc1d"),
   "definitionInformation" : {
     "definitionId" : "definition1", 
@@ -36,6 +36,26 @@ var publishedContent = {
   }, 
   "repository" : "d2t", 
   "contentId" : "content2", 
+  "itemType" : "content", 
+  "releaseId" : "publishedReleaseOnDelivery", 
+  "published" : true
+};
+
+var publishedContent3 = { 
+    "_id" : new ObjectID.createFromHexString("46b891d78a456d13026afc1e"),
+  "definitionInformation" : {
+    "definitionId" : "definition1", 
+    "definitionRevisionId" : "56a760163a1fde89024a7d99"
+  }, 
+  "tags" : [
+    "tag1"
+  ], 
+  "content" : {
+    "foo" : "bar",
+    "slug" : "slug2"
+  }, 
+  "repository" : "d2t", 
+  "contentId" : "content3", 
   "itemType" : "content", 
   "releaseId" : "publishedReleaseOnDelivery", 
   "published" : true
@@ -127,7 +147,8 @@ MongoClient.connect("mongodb://localhost:27017/dev_contentchef_delivery_v2", fun
   queries.insert(query);
   queries.insert(query2);
   deliveryItems.insert(unpublishedContent);
-  deliveryItems.insert(publishedContent);
+  deliveryItems.insert(publishedContent2);
+  deliveryItems.insert(publishedContent3);
   deliveryItems.insert(unpublishedWebPage);
   deliveryItems.insert(publishedWebPage);
 

--- a/src/api.js
+++ b/src/api.js
@@ -15,26 +15,31 @@
      * @param {int} cacheTimeToLive - The time to leave , in seconds, for the items in the cache (if not provided a default will be used)
      * @returns {Api} - The created api object
      */
-    var contentChef = function(deliveryUrl, spaceId, deliveryId, apiToken, apiCache, cacheTimeToLive) {
-        return contentChef.fn.initialize(deliveryUrl, spaceId, deliveryId, apiToken, apiCache, cacheTimeToLive);
+    var contentChef = function(deliveryUrl, spaceId, deliveryId, apiToken, apiCache, cacheTimeToLive, apiUrlDelivery) {
+        return contentChef.fn.initialize(deliveryUrl, spaceId, deliveryId, apiToken, apiCache, cacheTimeToLive, apiUrlDelivery);
     };
 
     var delivery = require('./delivery-module');
 
     contentChef.fn = contentChef.prototype = {
 
-        initialize: function(deliveryUrl, spaceId, deliveryId, apiToken, apiCache, cacheTimeToLive) {
+        initialize: function(deliveryUrl, spaceId, deliveryId, apiToken, apiCache, cacheTimeToLive, apiUrlDelivery) {
 
             var API_URL_DELIVERY = '/contentchef-delivery/v2';
-
-            delivery.setUrl(deliveryUrl + API_URL_DELIVERY);
-            delivery.setApiToken(apiToken);
             
             this.spaceId = spaceId;
             this.deliveryId = deliveryId;
 
             this.apiCache = apiCache || defaultGlobalCache(); // not used for now
             this.dataCacheTTL = cacheTimeToLive || 10;  // not used for now
+            
+            if (typeof apiUrlDelivery == 'undefined') {
+                this.apiUrlDelivery = API_URL_DELIVERY;
+            }
+            else this.apiUrlDelivery = apiUrlDelivery;
+
+            delivery.setUrl(deliveryUrl + this.apiUrlDelivery);
+            delivery.setApiToken(apiToken);
 
             return this;
         },
@@ -74,6 +79,10 @@
 
         listUnpublishedContentsByDefinition: function(definitionId, apiKeyForUnpublishedContent) {
             return delivery.listUnpublishedContentsByDefinition(this.spaceId, this.deliveryId, definitionId, apiKeyForUnpublishedContent);
+        },
+
+        listContentsByListOfContentIds: function(listOfContentIds) {
+            return delivery.listContentsByListOfContentIds(this.spaceId, this.deliveryId, listOfContentIds);
         },
 
         lookupWebPagesSitemapByUrl: function(baseURL, site) {

--- a/src/delivery-module.js
+++ b/src/delivery-module.js
@@ -61,6 +61,12 @@ module.exports = {
         return http.getItem(theFullUrl, mapSuccessfulResponseToContentList, header);
     },
 
+    listContentsByListOfContentIds: function(spaceId, deliveryId, listOfContentIds) {
+        var theFullUrl = url + '/' + encodeURIComponent(spaceId) + '/' + encodeURIComponent(deliveryId) + '/listContentsByListOfContentIds/' + encodeURIComponent(listOfContentIds);
+
+        return http.getItem(theFullUrl, mapSuccessfulResponseToContentList, header);
+    },
+
     listUnpublishedContentsByDefinition: function(spaceId, deliveryId, definitionId, authToken) {
         var theFullUrl = url + '/' + encodeURIComponent(spaceId) + '/' + encodeURIComponent(deliveryId) + '/listUnpublishedContentsByDefinitionId/' + encodeURIComponent(definitionId);
         var authHeader = {};

--- a/test/list-contents.spec.js
+++ b/test/list-contents.spec.js
@@ -1,11 +1,11 @@
 
 var cc = require('./../src/api');
-var api = cc.ContentChef.Api("http://localhost:9002", "d2t", "dev", "apiTokenWhatever");
+var api = cc.ContentChef.Api("http://localhost:9002", "d2t", "dev", "apiTokenWhatever", "apiCacheWhatever", 10, "");
 
 var chai = require("chai");
 chai.use(require("chai-as-promised"));
 
-var content = {
+var content2 = {
   "content": {
     "foo": "bar",
     "slug": "slug2"
@@ -16,6 +16,22 @@ var content = {
     "definitionRevisionId": "56a760163a1fde89024a7d99"
   },
   "revisionId": "56b891d78a456d13026afc1d",
+  "tags": [
+    "tag1"
+  ]
+};
+
+var content3 = {
+  "content": {
+    "foo": "bar",
+    "slug": "slug2"
+  },
+  "contentId": "content3",
+  "definitionInfo": {
+    "definitionId": "definition1",
+    "definitionRevisionId": "56a760163a1fde89024a7d99"
+  },
+  "revisionId": "46b891d78a456d13026afc1e",
   "tags": [
     "tag1"
   ]
@@ -45,7 +61,7 @@ describe("List contents by tag", function() {
   });
 
   it("should return proper result", function(){
-    return chai.expect(promise).to.eventually.become([content]);
+    return chai.expect(promise).to.eventually.become([content2, content3]);
   });
 
 });
@@ -59,7 +75,7 @@ describe("List contents by tag and definition", function() {
   });
 
   it("should return proper result", function(){
-    return chai.expect(promise).to.eventually.become([content]);
+    return chai.expect(promise).to.eventually.become([content2, content3]);
   });
 
 });
@@ -73,7 +89,7 @@ describe("List contents by definition", function() {
   });
 
   it("should return proper result", function(){
-    return chai.expect(promise).to.eventually.become([content]);
+    return chai.expect(promise).to.eventually.become([content2, content3]);
   });
 
 });
@@ -82,12 +98,29 @@ describe("List contents by definition and from-to", function() {
 
   var promise;
 
+  var contentWithSize = Object.create(content2);
+  contentWithSize.size = 2;
+
   beforeEach(function(){
     promise = api.listContentsByDefinitionFromTo("definition1", 0, 1);
   });
 
   it("should return proper result", function(){
-    return chai.expect(promise).to.eventually.become([content]);
+    return chai.expect(promise).to.eventually.become([contentWithSize]);
+  });
+
+});
+
+describe("List contents by list of content IDs", function() {
+
+  var promise;
+
+  beforeEach(function(){
+    promise = api.listContentsByListOfContentIds("content2,content3");
+  });
+
+  it("should return proper result", function(){
+    return chai.expect(promise).to.eventually.become([content2,content3]);
   });
 
 });

--- a/test/lookup-contents.spec.js
+++ b/test/lookup-contents.spec.js
@@ -1,6 +1,6 @@
 
 var cc = require('./../src/api');
-var api = cc.ContentChef.Api("http://localhost:9002", "d2t", "dev", "apiTokenWhatever");
+var api = cc.ContentChef.Api("http://localhost:9002", "d2t", "dev", "apiTokenWhatever", "apiCacheWhatever", 10, "");
 
 var chai = require("chai");
 chai.use(require("chai-as-promised"));

--- a/test/lookup-webpage.spec.js
+++ b/test/lookup-webpage.spec.js
@@ -1,6 +1,6 @@
 
 var cc = require('./../src/api');
-var api = cc.ContentChef.Api("http://localhost:9002", "d2t", "dev", "apiTokenWhatever");
+var api = cc.ContentChef.Api("http://localhost:9002", "d2t", "dev", "apiTokenWhatever", "apiCacheWhatever", 10, "");
 
 var chai = require("chai");
 chai.use(require("chai-as-promised"));


### PR DESCRIPTION
added listContentsByListOfContentIds endpoint;  
added parameter for API key in order to allow tests to run on address without /contentchef-delivery/v2;  
added extra content to test results;  
fixed error with missing size in from/to test;  